### PR TITLE
v0.1.0-alpha

### DIFF
--- a/example.c
+++ b/example.c
@@ -15,18 +15,19 @@ const char* DEFAULT_FILE = "tests/test.txt";
 
 int main()
 {
-    File_Reader* reader = open_file(DEFAULT_FILE);
+    File_Reader reader = open_file(DEFAULT_FILE);
 
-    if(reader && reader->contents)
+    if(reader.contents) 
     {
-        printf("File Size: %ld bytes\n", reader->size);
-        printf("%s", reader->contents);
+        printf("File Size: %ld bytes\n", reader.size);
+        printf("%s", reader.contents);
     }
     else
     {
         printf("File: '%s' was not found or was empty\n", DEFAULT_FILE);
     }
-    close_reader(reader);
+    
+    close_reader(&reader);
 
     return 0;
 }

--- a/include/file_reader.h
+++ b/include/file_reader.h
@@ -7,7 +7,6 @@
  * Author: Alexander DuPree
  *
  * https://github.com/AlexanderJDupree/File_Reader
- *
  */
 
 #ifndef FILE_READER_H
@@ -18,12 +17,12 @@
 
 typedef struct
 {
-    size_t size;
     FILE* file;
+    size_t size;
     const char* contents;
 } File_Reader;
 
-File_Reader* open_file(const char* file_name);
+File_Reader open_file(const char* file_name);
 
 void close_reader(File_Reader* reader);
 

--- a/release/file_reader.h
+++ b/release/file_reader.h
@@ -8,7 +8,7 @@
  *
  * https://github.com/AlexanderJDupree/File_Reader
  *
- * Version: v0.3-alpha
+ * Version: v0.1.0-alpha
  */
 
 #ifndef FILE_READER_H
@@ -20,12 +20,12 @@
 
 typedef struct
 {
-    size_t size;
     FILE* file;
+    size_t size;
     const char* contents;
 } File_Reader;
 
-File_Reader* open_file(const char* file_name);
+File_Reader open_file(const char* file_name);
 
 void close_reader(File_Reader* reader);
 
@@ -41,21 +41,17 @@ size_t file_size(FILE* file);
  * https://github.com/AlexanderJDupree/File_Reader
  */
 
-File_Reader* open_file(const char* file_name)
+File_Reader open_file(const char* file_name)
 {
     FILE* file = fopen(file_name, "r");
-    File_Reader* reader = NULL;
+    File_Reader reader = { .file = file, .size = 0, .contents = NULL };
 
-    if(file)  // if fopen failed, don't allocate and return NULL
+    if(file)  // if fopen was successfull, parse the file
     {
-        reader = (File_Reader*) malloc(sizeof(File_Reader));
+        reader.size = file_size(file);
 
-        reader->file = file;
-        reader->size = file_size(file);
-
-        reader->contents = read_file(reader);
+        reader.contents = read_file(&reader);
     }
-
     return reader;
 }
 
@@ -64,12 +60,13 @@ void close_reader(File_Reader* reader)
     if(reader)
     {
         free((char*)reader->contents);
+        reader->contents = NULL;
         if(reader->file)
         {
             fclose(reader->file);
+            reader->file = NULL;
         }
-        free(reader);
-        reader = NULL;
+        reader->size = 0;
     }
     return;
 }

--- a/src/file_reader.c
+++ b/src/file_reader.c
@@ -9,21 +9,17 @@
 #include <stdlib.h>
 #include "file_reader.h"
 
-File_Reader* open_file(const char* file_name)
+File_Reader open_file(const char* file_name)
 {
     FILE* file = fopen(file_name, "r");
-    File_Reader* reader = NULL;
+    File_Reader reader = { .file = file, .size = 0, .contents = NULL };
 
-    if(file)  // if fopen failed, don't allocate and return NULL
+    if(file)  // if fopen was successfull, parse the file
     {
-        reader = (File_Reader*) malloc(sizeof(File_Reader));
+        reader.size = file_size(file);
 
-        reader->file = file;
-        reader->size = file_size(file);
-
-        reader->contents = read_file(reader);
+        reader.contents = read_file(&reader);
     }
-
     return reader;
 }
 
@@ -32,12 +28,13 @@ void close_reader(File_Reader* reader)
     if(reader)
     {
         free((char*)reader->contents);
+        reader->contents = NULL;
         if(reader->file)
         {
             fclose(reader->file);
+            reader->file = NULL;
         }
-        free(reader);
-        reader = NULL;
+        reader->size = 0;
     }
     return;
 }

--- a/tests/prtests.cpp
+++ b/tests/prtests.cpp
@@ -23,12 +23,12 @@ const char* EMPTY_FILE = "tests/empty.txt";
 
 TEST_CASE("Determining a file size in bytes")
 {
-    File_Reader* reader = open_file(TEST_FILE);
-    File_Reader* empty_file = open_file(EMPTY_FILE);
+    File_Reader reader = open_file(TEST_FILE);
+    File_Reader empty_file = open_file(EMPTY_FILE);
 
     SECTION("test.txt size")
     {
-        REQUIRE(file_size(reader->file) == 22);
+        REQUIRE(file_size(reader.file) == 22);
     }
     SECTION("Invalid file")
     {
@@ -36,33 +36,34 @@ TEST_CASE("Determining a file size in bytes")
     }
     SECTION("empty_file")
     {
-        REQUIRE(file_size(empty_file->file) == 0);
+        REQUIRE(file_size(empty_file.file) == 0);
     }
-    close_reader(reader);
-    close_reader(empty_file);
+    close_reader(&reader);
+    close_reader(&empty_file);
 }
 
 TEST_CASE("Reading a file into a char buffer")
 {
-    File_Reader* reader = open_file(TEST_FILE);
-    File_Reader* invalid_file = open_file("not a file");
-    File_Reader* empty_reader = open_file(EMPTY_FILE);
+    File_Reader reader = open_file(TEST_FILE);
+    File_Reader invalid_file = open_file("not a file");
+    File_Reader empty_reader = open_file(EMPTY_FILE);
 
     SECTION("Read a valid file")
     {
         const char* test_contents = "Hello World\nI am Alex\n";
 
-        REQUIRE(strcmp(reader->contents, test_contents)== 0);
+        REQUIRE(strcmp(reader.contents, test_contents)== 0);
     }
     SECTION("Read invalid file")
     {
-        REQUIRE(read_file(invalid_file) == NULL);
+        REQUIRE(read_file(&invalid_file) == NULL);
     }
     SECTION("Read empty file")
     {
-        REQUIRE(empty_reader->contents == NULL);
+        REQUIRE(empty_reader.contents == NULL);
     }
-    close_reader(reader);
+    close_reader(&reader);
+    close_reader(&empty_reader);
     // Pointer for invalid_file never gets allocated. thus close_reader isn't needed
 }
 


### PR DESCRIPTION
The construction of the file reader has changed for this update, and thus can render previous code as incompatible. Instead of returning an allocated file reader, the reader is constructed locally and returned by value. The reason for this change is that it simplifies the code a bit and allows the reader to reused in the same scope. Previously, a call to close_reader would deallocate the reader; and opening another file would allocate a new reader. Now we can close the reader (deallocates the contents and closes the file pointer) and open a new file and just copy the relevant data over to the local reader object. 